### PR TITLE
Wrong user password for Fedora33

### DIFF
--- a/http/fedora33-kickstart.cfg
+++ b/http/fedora33-kickstart.cfg
@@ -9,7 +9,7 @@ network --bootproto=dhcp --device=eth0 --ipv6=auto --activate
 network --hostname=fedora33.localdomain
 selinux --disabled
 rootpw testtest
-user --groups=wheel --name=user --password=testest --uid=1000 --gecos="user" --gid=1000
+user --groups=wheel --name=user --password=testtest --uid=1000 --gecos="user" --gid=1000
 sshkey --username=user "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDUXg2vJmOBNIHd5j6gWFBs0/I4IWXp1jIHBn93FyUQsgiVOG82jhCA69G2SqCYbZHRJSJhwOFSMtMsvDno5Gz+tZMSASliiQnDD26YxiqZZUOApqCpdYKYEhwjVcokjKfm1rVdYhysk1K/qmlL6D0SVAzZxsepl7x8JksMVjvOsuGsZywsvh/Ck7JqEMt9O/NDWv0iFGkGy7J888eAnc+bMyiVV4ND+yYPqpCtL+fPU/dY7+LMR9uDoiJK8fAOmCrBvRLwmKOCh4NNRsHk58L36gl3ArUpNlqWrotpLROHhrXcuh4hSmPuTVsxQOTrzaHM2oVkw/+LBpFFqMLJrAaM8sVrfUBAhRD91cFHjazXg7RvXE1dbkPWDH6THJ71CS1FLyz2htMd7nYuJX/3J2bk533JKZVy/nOEtb0k2s1yCw4WNhT7M+RSFjsvgFsJJkvcGKPpIUwdkctzAXj4hAC1sdhiLsdh/j9E5yw2Tr6rRZ4nuBGDUOqlHABSZBm1d6k= packer-kvm-default-key"
 sshkey --username=root "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDUXg2vJmOBNIHd5j6gWFBs0/I4IWXp1jIHBn93FyUQsgiVOG82jhCA69G2SqCYbZHRJSJhwOFSMtMsvDno5Gz+tZMSASliiQnDD26YxiqZZUOApqCpdYKYEhwjVcokjKfm1rVdYhysk1K/qmlL6D0SVAzZxsepl7x8JksMVjvOsuGsZywsvh/Ck7JqEMt9O/NDWv0iFGkGy7J888eAnc+bMyiVV4ND+yYPqpCtL+fPU/dY7+LMR9uDoiJK8fAOmCrBvRLwmKOCh4NNRsHk58L36gl3ArUpNlqWrotpLROHhrXcuh4hSmPuTVsxQOTrzaHM2oVkw/+LBpFFqMLJrAaM8sVrfUBAhRD91cFHjazXg7RvXE1dbkPWDH6THJ71CS1FLyz2htMd7nYuJX/3J2bk533JKZVy/nOEtb0k2s1yCw4WNhT7M+RSFjsvgFsJJkvcGKPpIUwdkctzAXj4hAC1sdhiLsdh/j9E5yw2Tr6rRZ4nuBGDUOqlHABSZBm1d6k= packer-kvm-default-key"
 timezone Europe/Paris --isUtc


### PR DESCRIPTION
The user password in fedora33.json is testtest.
In http/fedora33-kickstart.cfg there is a type, where one 't' is missing in the password.