### PR TITLE
Add Samba support for Packer QEMU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM hashicorp/packer:light
 
-RUN apk add --update qemu qemu-system-x86_64 qemu-img openssh python3 py3-pip
+RUN apk add --update qemu qemu-system-x86_64 qemu-img openssh python3 py3-pip samba


### PR DESCRIPTION
Adding Samba into Packer docker to enable SMB support whenever we share
a directory or file into the packer build.

e.g. -net nic -net user,smb=shared_folder_path