### PR TITLE
fix debian preseed/late_command

### DIFF
--- a/http/debian-preseed.cfg
+++ b/http/debian-preseed.cfg
@@ -44,7 +44,7 @@ d-i grub-installer/only_debian boolean true
 d-i grub-installer/bootdev  string /dev/vda
 
 # script
-d-i preseed/late_command in-target sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /target/etc/ssh/sshd_config
+d-i preseed/late_command string in-target sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
 # finish
 d-i finish-install/reboot_in_progress note


### PR DESCRIPTION
add variable type and then fix-up sed to be run inside the target (remove '/target')